### PR TITLE
Fix typo in tests of fourth list

### DIFF
--- a/text/fourth-symmetry.md
+++ b/text/fourth-symmetry.md
@@ -97,7 +97,7 @@ fn basics() {
     // ---- back -----
 
     // Check empty list behaves right
-    assert_eq!(list.pop_front(), None);
+    assert_eq!(list.pop_back(), None);
 
     // Populate list
     list.push_back(1);


### PR DESCRIPTION
The first assert of the "back" methods should call `pop_back`, not `pop_front`. It's already that way in the source file (lists/src/fourth.rs).