### PR TITLE
more torough test

### DIFF
--- a/text/second-into-iter.md
+++ b/text/second-into-iter.md
@@ -65,6 +65,7 @@ fn into_iter() {
     assert_eq!(iter.next(), Some(3));
     assert_eq!(iter.next(), Some(2));
     assert_eq!(iter.next(), Some(1));
+    assert_eq!(iter.next(), None);
 }
 ```
 


### PR DESCRIPTION
Add an assert to completely test pop() when it should return None.
If that's OK with you I can submit some other patches to do the same for iter and itermut.